### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13

--- a/rest_ingest.json
+++ b/rest_ingest.json
@@ -17,7 +17,7 @@
     "license": "Copyright (c) 2016-2025 Splunk Inc.",
     "fips_compliant": true,
     "product_version_regex": ".*",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "require_auth_token": true,
     "latest_tested_versions": [
         ""


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)