### PR TITLE
docs: replace outdated phantom links with SOAR documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,7 +27,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.14.11
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -43,7 +43,7 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
@@ -60,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.9
+    rev: v2.1.1
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: REST Data Source
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ Minimum Product Version: 6.3.0
 
 This app implements custom REST handlers for external implementations to push ingest data such as events and artifacts into Phantom
 
-This App is an Ingestion source. In the Phantom documentation, in the [Administration
-Manual](../admin/) under the [Data Sources](../admin/sources) section, you will find an explanation
-of how Ingest Apps works and how information is extracted from the ingested data. There is a general
-explanation in Overview, and some individuals Apps have their own sections.
+This app is a data ingestion source for Splunk SOAR. Unlike typical SOAR apps that perform actions (like blocking IPs or quarantining endpoints), this app allows external systems to push security event data into SOAR in real-time via REST endpoints.
 
-A video explaining the configuration of a REST Asset for ingestion can be found on the Phantom
-portal at [this link](https://my.phantom.us/video/4)
+When data is received, the app parses it into SOAR containers (security events) and artifacts (observables like IPs, file hashes, domains). These containers and artifacts can then trigger automated playbooks and response workflows in SOAR.
+
+This app supports two parsing options:
+
+- **Stock Scripts**: Pre-built parsers for STIX 1.2 and FireEye alert formats
+- **Custom Scripts**: Upload your own Python script to parse any data format
+
+For details on writing custom parser scripts for this app, see [Using custom scripts with the Splunk SOAR REST API](https://help.splunk.com/en/splunk-soar/soar-cloud/rest-api-reference/using-the-splunk-soar-rest-api/use-a-custom-script)
 
 ## jsonpath_rw
 
@@ -79,7 +82,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -1,10 +1,13 @@
-This App is an Ingestion source. In the Phantom documentation, in the [Administration
-Manual](../admin/) under the [Data Sources](../admin/sources) section, you will find an explanation
-of how Ingest Apps works and how information is extracted from the ingested data. There is a general
-explanation in Overview, and some individuals Apps have their own sections.
+This app is a data ingestion source for Splunk SOAR. Unlike typical SOAR apps that perform actions (like blocking IPs or quarantining endpoints), this app allows external systems to push security event data into SOAR in real-time via REST endpoints.
 
-A video explaining the configuration of a REST Asset for ingestion can be found on the Phantom
-portal at [this link](https://my.phantom.us/video/4)
+When data is received, the app parses it into SOAR containers (security events) and artifacts (observables like IPs, file hashes, domains). These containers and artifacts can then trigger automated playbooks and response workflows in SOAR.
+
+This app supports two parsing options:
+
+- **Stock Scripts**: Pre-built parsers for STIX 1.2 and FireEye alert formats
+- **Custom Scripts**: Upload your own Python script to parse any data format
+
+For details on writing custom parser scripts for this app, see [Using custom scripts with the Splunk SOAR REST API](https://help.splunk.com/en/splunk-soar/soar-cloud/rest-api-reference/using-the-splunk-soar-rest-api/use-a-custom-script)
 
 ## jsonpath_rw
 

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/parsers/fireeye_rest_handler.py
+++ b/parsers/fireeye_rest_handler.py
@@ -1,7 +1,7 @@
 # !/bin/env python
 # File: fireeye_rest_handler.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/parsers/stix_rest_handler.py
+++ b/parsers/stix_rest_handler.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python2.7
 # File: stix_rest_handler.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* replace outdated phantom references with current Splunk SOAR link. 

--- a/rest_connector.py
+++ b/rest_connector.py
@@ -1,6 +1,6 @@
 # File: rest_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rest_ingest.json
+++ b/rest_ingest.json
@@ -14,7 +14,7 @@
     "min_phantom_version": "6.3.0",
     "logo": "logo_restapi.svg",
     "logo_dark": "logo_restapi_dark.svg",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "fips_compliant": true,
     "product_version_regex": ".*",
     "python_version": "3.9, 3.13",


### PR DESCRIPTION
* Replaced outdated documentation with current SOAR docs
* Existing documentation had generic information  and also a link to a video which is now not available. https://splunk.atlassian.net/browse/SOARHELP-5713?focusedCommentId=18067792
*